### PR TITLE
Handle empty BM25 corpus

### DIFF
--- a/rag/bm25_index.py
+++ b/rag/bm25_index.py
@@ -28,12 +28,14 @@ class BM25ChunkIndex:
     def build(self, chunks: Sequence[Chunk]) -> None:
         self._chunks = list(chunks)
         self._tok_corpus = [_tokenize(c.text) for c in self._chunks]
-        corpus = self._tok_corpus if self._tok_corpus else [[""]]
-        self._bm25 = BM25Okapi(corpus)
+        if self._tok_corpus:
+            self._bm25 = BM25Okapi(self._tok_corpus)
+        else:
+            self._bm25 = None
 
     def search(self, query: str, k: int = 5) -> List[ScoredChunk]:
-        if self._bm25 is None:
-            raise RuntimeError("Index not built. Call build() first.")
+        if self._bm25 is None or not self._chunks:
+            return []
         toks = _tokenize(query)
         scores = self._bm25.get_scores(toks)
         order = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:k]

--- a/rag/tests/test_bm25.py
+++ b/rag/tests/test_bm25.py
@@ -11,3 +11,9 @@ def test_bm25_ranks_relevant_higher():
     idx.build(chunks_a + chunks_b)
     top = idx.search("felines purr", k=1)[0]
     assert top.chunk.doc_id == "A"
+
+
+def test_empty_build_search_returns_empty_list():
+    idx = BM25ChunkIndex()
+    idx.build([])
+    assert idx.search("anything") == []


### PR DESCRIPTION
## Summary
- Avoid building a BM25 index on an empty corpus by leaving the index unset
- Return an empty result list when searching an unbuilt or empty BM25 index
- Add regression test ensuring search on an empty index returns []

## Testing
- `python -m pre_commit run --files rag/bm25_index.py rag/tests/test_bm25.py`
- `pytest --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_b_68b218b3d340832fa5433fff14fc9f0a